### PR TITLE
Update rollup version to ^0.25.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,9 +11,13 @@
   ],
   "author": "Chad Hietala <chadhietala@gmail.com>",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/chadhietala/broccoli-rollup"
+  },
   "dependencies": {
     "broccoli-caching-writer": "^2.2.0",
-    "rollup": "^0.21.0"
+    "rollup": "^0.25.8"
   },
   "devDependencies": {
     "broccoli-fixture": "^0.1.0",


### PR DESCRIPTION
This bumps rollup to ^0.25.8 and also adds a repository field in package.json so it'll get picked up on the npm site.

Since `rollup` is a `0.x` version the `^` doesn't do much good for resolving newer versions. Oh well.
