### PR TITLE
Update rollup to version ^0.26.2.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+fixtures/tmp
 node_modules

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "broccoli-caching-writer": "^2.2.0",
-    "rollup": "^0.25.8"
+    "rollup": "^0.26.2"
   },
   "devDependencies": {
     "broccoli-fixture": "^0.1.0",


### PR DESCRIPTION
`npm test` passes with the new version of rollup. I'm hoping to pull in a new version to get a fix for this bug: https://github.com/rollup/rollup/issues/618
