### PR TITLE
Set (and accept) `sourceMapFile` option so source map top-level package is not name of temporay directory

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,9 @@ var rollup = require('rollup').rollup;
 var path = require('path');
 var fs = require('fs');
 
+// Keys to remove from options for main call to Rollup
+var bundleOnlyKeys = ['sourceMapFile'];
+
 module.exports = Rollup;
 Rollup.prototype = Object.create(CachingWriter.prototype);
 Rollup.prototype.constructor = Rollup;
@@ -22,7 +25,20 @@ function Rollup(inputNode, options) {
   });
   
   this.inputFiles = options.inputFiles;
-  this.rollupOptions = options.rollup;
+
+  var rollupOptions = options.rollup;
+
+  // Pull out config for sourceMapFile (sets path/name of source map top-level)
+  this.rollupSourceMapFile = rollupOptions.sourceMapFile || rollupOptions.moduleName || rollupOptions.dest;
+
+  // Remove keys which Rollup main call won't accept
+  bundleOnlyKeys.forEach(function(key) {
+    delete rollupOptions[key];
+  });
+
+  this.rollupOptions = rollupOptions;
+  this.rollupBundleOptions = Object.create(this.rollupOptions);
+
   this.rollupEntry = null;
   this.rollupDest = null;
 }
@@ -36,8 +52,11 @@ Rollup.prototype.build = function() {
   this.rollupOptions.entry = this.rollupEntry 
   this.rollupOptions.dest = this.rollupDest;
 
+  // Set sourceMapFile relative to source directory to avoid temporary directory path in source map
+  this.rollupBundleOptions.sourceMapFile = path.join(this.inputPaths[0], this.rollupSourceMapFile);
+
   return rollup(this.rollupOptions).then(function(bundle) {
-    return bundle.write(this.rollupOptions);
+    return bundle.write(this.rollupBundleOptions);
   }.bind(this)).catch(function(err) {
     throw new Error(err);
   });


### PR DESCRIPTION
This change uses the destination file name (or provided file name) as the source map's top level package instead of the Broccoli temporary directory of the input tree, making it look much more appealing.

Previously the top level package was `../rollup-input_base_path-xxxxxxxx.tmp` as the bundle was built in the output tree, the `sourceMapFile` was being set to the destination file (the bundle) but as an absolute path. From the [Rollup docs](https://github.com/rollup/rollup/wiki/JavaScript-API#sourcemapfile):

> If this is an absolute path, all the sources paths in the sourcemap will be relative to it.
