### PR TITLE
Bump `rollup` to 0.41.4 and update Node versions used in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 language: node_js
 node_js:
-  - "0.10"
-  - "0.12"
   - "4"
-  - "5"
+  - "6"
 
 before_install:
   - "npm config set spin false"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,8 @@
 # Test against these versions of Node.js.
 environment:
   matrix:
-    - nodejs_version: "0.12"
+    - nodejs_version: "4"
+    - nodejs_version: "6"
 
 # Install scripts. (runs after repo cloning)
 install:

--- a/package.json
+++ b/package.json
@@ -25,6 +25,9 @@
     "dist/",
     "!dist/tests"
   ],
+  "engines" : {
+    "node" : ">=4.0"
+  },
   "devDependencies": {
     "broccoli": "^0.16.9",
     "broccoli-babel-transpiler": "^5.6.0",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,6 @@
     "heimdalljs": "^0.2.1",
     "heimdalljs-logger": "^0.1.7",
     "md5-hex": "^1.3.0",
-    "rollup": "^0.34.11"
+    "rollup": "^0.41.4"
   }
 }

--- a/tests/index.js
+++ b/tests/index.js
@@ -42,9 +42,8 @@ describe('BroccoliRollup', function() {
 
     it('simple', async function() {
       const { directory } = await pipeline.build();
-
       expect(file(directory + '/out.js'))
-        .to.equal('var add = x => x + x;\n\nconst two = add(1);\n\nexport default two;');
+        .to.equal('var add = x => x + x;\n\nconst two = add(1);\n\nexport default two;\n');
     });
 
     describe('rebuild', function() {
@@ -59,12 +58,12 @@ describe('BroccoliRollup', function() {
         fixture.writeSync(input, { 'minus.js':  'export default x => x - x;' });
 
         expect(file(directory + '/out.js'))
-          .to.equal('var add = x => x + x;\n\nconst two = add(1);\n\nexport default two;');
+          .to.equal('var add = x => x + x;\n\nconst two = add(1);\n\nexport default two;\n');
 
         await pipeline.build();
 
         expect(file(directory + '/out.js'))
-          .to.equal('var add = x => x + x;\n\nconst two = add(1);\n\nexport default two;');
+          .to.equal('var add = x => x + x;\n\nconst two = add(1);\n\nexport default two;\n');
 
         fixture.writeSync(input, {
           'index.js': 'import add from "./add"; import minus from "./minus"; export default { a: add(1), b: minus(1) };'
@@ -73,7 +72,7 @@ describe('BroccoliRollup', function() {
         await pipeline.build();
 
         expect(file(directory + '/out.js'))
-          .to.equal('var add = x => x + x;\n\nvar minus = x => x - x;\n\nvar index = { a: add(1), b: minus(1) };\n\nexport default index;');
+          .to.equal('var add = x => x + x;\n\nvar minus = x => x - x;\n\nvar index = { a: add(1), b: minus(1) };\n\nexport default index;\n');
 
         fixture.writeSync(input, { 'minus.js':  null });
 
@@ -93,7 +92,7 @@ describe('BroccoliRollup', function() {
         await pipeline.build();
 
         expect(file(directory + '/out.js'))
-          .to.equal('var add = x => x + x;\n\nvar index = add(1);\n\nexport default index;');
+          .to.equal('var add = x => x + x;\n\nvar index = add(1);\n\nexport default index;\n');
       });
 
       describe('stability', function(){
@@ -165,7 +164,7 @@ const two = add(1);
 
 return two;
 
-})));`);
+})));\n`);
 
     });
 
@@ -204,6 +203,7 @@ return two;
 const two = add(1);
 
 export default two;
+
 //# sourceMappingURL=out.js.map
 `);
 
@@ -223,7 +223,7 @@ const two = add(1);
 
 return two;
 
-})));`);
+})));\n`);
 
 
     });


### PR DESCRIPTION
1. Bumped `rollup` to 0.41.4
2. Added trailing whitespace characters coming from changes to rollup output.  Since these are meaningless, I _could_ just do a trim and compare.
3. Updated CI files to leverage Node 4 and 6, since `rollup` itself no longer does CI builds on versions lower than 4 (see https://github.com/rollup/rollup/commit/21a5d0d0622ca9a1ea722479162939beff8c9a3f)