### PR TITLE
Allow for node_modules path to be configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ var Rollup = require('broccoli-rollup');
 var lib = 'lib';
 
 module.exports = new Rollup(lib, {
+  // nodeModulesPath: string Defaults to process.cwd()
   rollup: {
     entry: 'lib/index.js',
     dest: 'my-lib.js',

--- a/src/index.js
+++ b/src/index.js
@@ -39,13 +39,19 @@ export default class Rollup extends Plugin {
     this.lastTree = FSTree.fromEntries([]);
     this.linkedModules = false;
     this.cache = options.cache === undefined ? true : options.cache;
+
+    if ('nodeModulesPath' in options && !path.isAbsolute(options.nodeModulesPath)) {
+      throw new Error(`nodeModulesPath must be fully qualified and you passed a relative path`);
+    }
+
+    this.nodeModulesPath = options.nodeModulesPath || nodeModulesPath(process.cwd());
   }
 
   build() {
     let { lastTree, linkedModules } = this;
 
     if (!linkedModules) {
-      symlinkOrCopySync(nodeModulesPath(process.cwd()), `${this.cachePath}/node_modules`);
+      symlinkOrCopySync(this.nodeModulesPath, `${this.cachePath}/node_modules`);
       this.linkedModules = true;
     }
 

--- a/tests/index.js
+++ b/tests/index.js
@@ -270,5 +270,19 @@ return two;
 
 
     });
-  })
+  });
+
+  describe('passing nodeModulesPath', function() {
+    it('should throw if nodeModulesPath is relative', function() {
+      expect(function() {
+        new Rollup('lib', {
+          nodeModulesPath: './',
+          rollup: {
+            entry: 'index.js',
+            dest: 'out.js'
+          }
+        });
+      }).to.throw(/nodeModulesPath must be fully qualified and you passed a relative path/);
+    });
+  });
 });


### PR DESCRIPTION
Prior to this commit we would assume the node_modules you were
attempting to rollup resided at `process.cwd()`, however if you are in a
deps of deps scenario (transitives) it may be required to use a different
resolution to node_modules. This makes this path configurable, by
allowing the caller to pass a fully qualified path to the node_modules
directory in which they want to resolve and rollup.