### PR TITLE
Use fs.copyFileSync if available

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,10 @@ import {
   rmdirSync,
   unlinkSync,
   writeFileSync,
-  readFileSync
+  readFileSync,
+  copyFileSync,
+  existsSync,
+  constants as fsConstants
 } from 'fs';
 import { tmpdir } from 'os';
 import { entries } from 'walk-sync';
@@ -21,10 +24,18 @@ import 'es6-map/implement';
 
 const logger = _logger('broccoli-rollup');
 
-function deref(srcPath, destPath) {
-  let content = readFileSync(srcPath);
-  writeFileSync(destPath, content);
-}
+const deref = typeof copyFileSync === 'function' ?
+  (srcPath, destPath) => {
+    if (existsSync(destPath)) {
+      unlinkSync(destPath);
+    }
+
+    copyFileSync(srcPath, destPath, fsConstants.COPYFILE_EXCL);
+  } :
+  (srcPath, destPath) => {
+    let content = readFileSync(srcPath);
+    writeFileSync(destPath, content);
+  };
 
 export default class Rollup extends Plugin {
   constructor(node, options = {}) {


### PR DESCRIPTION
More efficient copying with node >= 8.5

This seems faster even with the additional `existsSync` + `unlickSync` call.
I've tested this with ~10 ~2K javascript files, the old version took (with warmed fs cache) around 5ms while the new version took 2ms on my machine.

See: https://nodejs.org/en/blog/release/v8.5.0/
Yarn had huge improvements with fs.copyFile: yarnpkg/yarn#4486