### PR TITLE
Support Rollup plugins that use null byte paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "heimdalljs": "^0.2.6",
     "node-modules-path": "^1.0.1",
     "rollup": "^1.12.0",
+    "rollup-pluginutils": "^2.8.1",
     "symlink-or-copy": "^1.2.0",
     "walk-sync": "^1.1.3"
   },

--- a/src/dependencies.ts
+++ b/src/dependencies.ts
@@ -1,9 +1,11 @@
 import { RollupBuild } from 'rollup';
+import { createFilter } from 'rollup-pluginutils';
 import { Operation, realpath } from './utils';
 
 export default class Dependencies {
   private buildPath: string;
   private inputDependencies = new Set<string>();
+  private filter = createFilter();
 
   constructor(buildPath: string) {
     this.buildPath = realpath(buildPath);
@@ -17,6 +19,8 @@ export default class Dependencies {
     const inputDependencies = new Set<string>();
 
     for (const watchedFile of watchedFiles) {
+      if (!this.filter(watchedFile)) { continue; }
+
       const normalized = realpath(watchedFile);
       if (normalized.startsWith(buildPath)) {
         inputDependencies.add(normalized.slice(relativeStart));

--- a/yarn.lock
+++ b/yarn.lock
@@ -711,6 +711,11 @@ esprima@^4.0.0:
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
 
+estree-walker@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.6.1.tgz#53049143f40c6eb918b23671d1fe3219f3a1b362"
+  integrity sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==
+
 esutils@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
@@ -2090,6 +2095,13 @@ rimraf@^2.2.8, rimraf@^2.3.4, rimraf@^2.5.4, rimraf@^2.6.2, rimraf@^2.6.3:
   integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
   dependencies:
     glob "^7.1.3"
+
+rollup-pluginutils@^2.8.1:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-2.8.1.tgz#8fa6dd0697344938ef26c2c09d2488ce9e33ce97"
+  integrity sha512-J5oAoysWar6GuZo0s+3bZ6sVZAC0pfqKz68De7ZgDi5z63jOVZn1uJL/+z1jeKHNbGII8kAyHF5q8LnxSX5lQg==
+  dependencies:
+    estree-walker "^0.6.1"
 
 rollup@^1.12.0:
   version "1.12.0"


### PR DESCRIPTION
Rollup has an informal convention where plugins create module IDs with a null byte (`\u0000`) in the string. For example, rollup-plugin-commonjs creates a virtual module called `\u0000commonjsHelpers.js`. This convention helps catch bugs because you'll get an early error if you try to interact with that path in the real file system.

Unfortunately, plugins that generate these module IDs currently cause broccoli-rollup to crash. This is because virtual modules are included in the `watchedFiles` list returned from Rollup after the bundle build completes. When we try to normalize these paths, an error like the following is produced:

```
NodeError: The argument 'path' must be a string or Uint8Array without null bytes. Received '\u0000commonjsHelpers.js'
```

This PR uses the `createFilter` functionality provided by the `rollup-pluginutils` package to filter out paths that should not be checked during rebuilds. This is the same function Rollup's own built-in watcher uses to filter out paths from `watchedFiles` that should not be watched. While we could avoid adding an extra dependency and check just for null bytes in module IDs, this seemed like a more robust solution that will help us catch more cases like this in the future.